### PR TITLE
let's compile it from source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include README.md
+include requirements.txt
+include requirements_setup.txt
+include requirements_test.txt

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/timmo001/system-bridge-models",
     install_requires=requirements,
-    packages=find_packages(exclude=["tests", "generator"]),
+    packages=find_packages(exclude=["tests", "tests.*", "generator"]),
     python_requires=">=3.11",
     setup_requires=requirements_setup,
     use_incremental=True,


### PR DESCRIPTION
1. some file in Pypi's SDIST are missing, added a MANIFEST.in
2. 'tests' is still installed in top level, updated the exclude
```
 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.11/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
 * ERROR: dev-python/systembridgemodels-4.0.4::HomeAssistantRepository failed (install phase):
 *   Failing install because of stray top-level files in site-packages
 *
 * Call stack:
 *     ebuild.sh, line  136:  Called src_install
 *   environment, line 3900:  Called distutils-r1_src_install
 *   environment, line 1886:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_install'
 *   environment, line  727:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3512:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3061:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 3059:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_install'
 *   environment, line 1176:  Called distutils-r1_run_phase 'distutils-r1_python_install'
 *   environment, line 1849:  Called _distutils-r1_post_python_install
 *   environment, line  619:  Called die
 * The specific snippet of code:
 *               die "Failing install because of stray top-level files in site-packages";
 *
 * If you need support, post the output of `emerge --info '=dev-python/systembridgemodels-4.0.4::HomeAssistantRepository'`,
 * the complete build log and the output of `emerge -pqv '=dev-python/systembridgemodels-4.0.4::HomeAssistantRepository'`.
 * The complete build log is located at '/var/tmp/portage/dev-python/systembridgemodels-4.0.4/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/dev-python/systembridgemodels-4.0.4/temp/environment'.
 * Working directory: '/var/tmp/portage/dev-python/systembridgemodels-4.0.4/work/system-bridge-models-4.0.4'
 * S: '/var/tmp/portage/dev-python/systembridgemodels-4.0.4/work/system-bridge-models-4.0.4'
 *
```

2. some file in Pypi's SDIST are missing, added a MANIFEST.in